### PR TITLE
entrypointを指定する場合のコマンド例を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,16 @@ $ docker run \
 を指定して、JVM メモリを拡張してください。
 
 ```bash
---entrypoint "java -Xmx2048m -cp ./jamcha.jar jp.co.tdc.jamcha.cmd.Main"
+$ docker run \
+  -v "/path/to/src:/src" \
+  -v "/path/to/libs:/libs" \
+  -v "/path/to/reports:/reports" \
+  ghcr.io/tdc-yamada-ya/jamcha \
+  -Xmx2048m -cp ./jamcha.jar jp.co.tdc.jamcha.cmd.Main \
+  -i /src \
+  -s /src \
+  -l /libs \
+  -o /reports
 ```
 
 ## 制限事項


### PR DESCRIPTION
突然のPR失礼します。
Readmeのコマンド例でentrypointの指定が動作しない箇所があったため修正しました。（entrypointの引数をイメージ名の後に指定する必要がありました）

jamchaを使うとコードの依存関係を自動で解析できるため重宝しております。